### PR TITLE
Got the "code" flow with PKCE working

### DIFF
--- a/AspNetWebFormImplicitFlow/Web.config
+++ b/AspNetWebFormImplicitFlow/Web.config
@@ -6,6 +6,7 @@
 <configuration>
   <appSettings>
     <add key="Oidc:ClientId" value="webforms.owin.pkce" />
+    <add key="Oidc:ClientSecret" value="20b26a16-6f5b-cbd9-e151-ce52a814c09e" />
     <add key="Oidc:Authority" value="https://localhost:44310" />
     <add key="Oidc:UserInfoEndpoint" value="/connect/userinfo" />
     <add key="Oidc:TokenInfoEndpoint" value="/connect/token" />
@@ -95,4 +96,13 @@
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
+
+  <location path="About">
+    <system.web>
+      <authorization>
+        <deny users="?" />
+      </authorization>
+    </system.web>
+  </location>
+
 </configuration>


### PR DESCRIPTION
Had to turn off some OpenIdConnectProtocolValidator options (**RequireNonce=false**, **RequireState=false**) to make it work with the IdentityServer4 based STS.

Use the **About** link to try. The **Login** link doesn't work.
And don't forget to adapt the **ClientSecret** in **Web.config**.

Used the following client settings (not sure if all of them are required, but at least this combo works):
```
Require Client Secret=true
Require Request Object=false
Require Pkce=true
Allow Plain Text Pkce=true
Allow Offline Access=false
Allow Access Token Via Brower=false
Allowed Scopes=email openid profile roles
Allowed Grant Types=code authorization_code
```